### PR TITLE
dev(narugo): add parallel download for data sources

### DIFF
--- a/test/utils/test_idorder.py
+++ b/test/utils/test_idorder.py
@@ -1,0 +1,34 @@
+import pytest
+
+from waifuc.utils import IDOrder
+
+
+@pytest.fixture()
+def idorder():
+    yield IDOrder()
+
+
+@pytest.mark.unittest
+class TestUtilsIdorder:
+    @pytest.mark.parametrize(['try_cnt'], [(i_,) for i_ in range(1, 11)])
+    def test_idorder(self, idorder, try_cnt):
+        assert not idorder.is_set_id(0)
+        assert not idorder.is_set_id(1)
+        assert not idorder.is_set_id(2)
+        assert not idorder.is_set_id(10)
+
+        assert not idorder.wait_for_id(0, timeout=0.5)
+        assert not idorder.wait_for_id(2, timeout=0.5)
+        idorder.set_id(0)
+        assert idorder.wait_for_id(0)
+        assert not idorder.wait_for_id(2, timeout=0.5)
+
+        assert not idorder.wait_for_id(2, timeout=0.5)
+        idorder.set_id(2)
+        assert idorder.wait_for_id(2)
+        assert idorder.is_set_id(2)
+        assert idorder.wait_for_id(0)
+        assert idorder.is_set_id(0)
+        assert not idorder.is_set_id(1)
+        assert idorder.is_set_id(2)
+        assert not idorder.is_set_id(10)

--- a/test/utils/test_orderer.py
+++ b/test/utils/test_orderer.py
@@ -1,7 +1,111 @@
+import time
+from concurrent.futures import ThreadPoolExecutor
+from threading import Lock, Event
+from typing import Optional
+
 import pytest
+
+from waifuc.utils import NoBlockOrderer, SerializableOrderer
+
+
+@pytest.fixture()
+def no_block():
+    yield NoBlockOrderer()
+
+
+@pytest.fixture()
+def serializable():
+    yield SerializableOrderer()
+
+
+@pytest.fixture()
+def thread_pool():
+    tp = ThreadPoolExecutor(max_workers=36)
+    try:
+        yield tp
+    finally:
+        tp.shutdown(wait=True)
+
+
+class ValueEvent:
+    def __init__(self):
+        self._event = Event()
+        self._value = None
+        self._lock = Lock()
+
+    def put_value(self, value):
+        with self._lock:
+            self._event.set()
+            self._value = value
+
+    def wait(self, timeout: Optional[float] = None):
+        return self._event.wait(timeout=timeout)
+
+    @property
+    def is_set(self):
+        with self._lock:
+            return self._event.is_set()
+
+    @property
+    def value(self):
+        with self._lock:
+            return self._value
 
 
 @pytest.mark.unittest
 class TestUtilsOrderer:
-    def test_okay(self):
-        pass
+
+    def test_no_block_orderer(self, no_block):
+        assert no_block.current == -1
+        assert no_block.wait_for_num(100)
+        assert no_block.step() == 0
+        assert no_block.wait_for_num(0)
+        assert no_block.wait_for_num(100)
+        assert no_block.step() == 1
+        assert no_block.wait_for_num(0)
+        assert no_block.wait_for_num(100)
+
+    @pytest.mark.parametrize(['try_cnt'], [(i_,) for i_ in range(1, 11)])
+    def test_serializable(self, serializable, thread_pool, try_cnt):
+        assert serializable.current == -1
+
+        def _get_wait_event(num):
+            _value = ValueEvent()
+
+            def _call():
+                value = serializable.wait_for_num(num)
+                _value.put_value(value)
+
+            thread_pool.submit(_call)
+            return _value
+
+        with pytest.raises(ValueError):
+            serializable.wait_for_num(-100)
+
+        v0 = _get_wait_event(0)
+        assert not v0.is_set
+        time.sleep(0.5)
+        assert not v0.is_set
+
+        assert serializable.step() == 0
+        assert v0.wait()
+        assert v0.is_set
+
+        v1, v2, v10 = _get_wait_event(1), _get_wait_event(2), _get_wait_event(10)
+        assert serializable.step() == 1
+        assert v1.wait()
+        assert v1.is_set
+        assert serializable.wait_for_num(0)
+
+        assert not v2.wait(0.5)
+        assert serializable.step() == 2
+        assert v2.wait()
+        assert v2.is_set
+
+        assert not v10.wait(0.5)
+        v10x = _get_wait_event(10)
+        assert not v10x.wait(0.5)
+        assert [serializable.step() for i in range(10)] == [3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+        assert v10.wait()
+        assert v10.is_set
+        assert v10x.is_set

--- a/test/utils/test_orderer.py
+++ b/test/utils/test_orderer.py
@@ -1,0 +1,7 @@
+import pytest
+
+
+@pytest.mark.unittest
+class TestUtilsOrderer:
+    def test_okay(self):
+        pass

--- a/test/utils/test_orderer.py
+++ b/test/utils/test_orderer.py
@@ -108,4 +108,5 @@ class TestUtilsOrderer:
         assert [serializable.step() for i in range(10)] == [3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
         assert v10.wait()
         assert v10.is_set
+        assert v10x.wait()
         assert v10x.is_set

--- a/test/utils/test_serial.py
+++ b/test/utils/test_serial.py
@@ -1,0 +1,82 @@
+import random
+import time
+from threading import Event, Thread
+
+import pytest
+
+from waifuc.utils import SerializableParallelModule, Stopped
+
+
+def _calc_fn(x):
+    time.sleep(random.random() * 0.5)
+    return x ** 2
+
+
+@pytest.fixture()
+def serial():
+    s = SerializableParallelModule(max_workers=4)
+    try:
+        yield s
+    finally:
+        s.join()
+
+
+@pytest.fixture()
+def send_20_nums(serial):
+    event = Event()
+
+    def _t():
+        for i in range(20):
+            try:
+                serial.submit_task(_calc_fn, i)
+            except Stopped:
+                break
+
+        event.set()
+        time.sleep(0.5)
+        serial.shutdown()
+        serial.join()
+
+    thread = Thread(target=_t)
+    thread.start()
+
+    try:
+        yield thread, event
+    finally:
+        thread.join()
+
+
+@pytest.fixture()
+def sending_thread(send_20_nums):
+    thread, _ = send_20_nums
+    yield thread
+
+
+@pytest.fixture()
+def send_end_event(send_20_nums):
+    _, event = send_20_nums
+    yield event
+
+
+@pytest.mark.unittest
+class TestUtilsSerial:
+    @pytest.mark.parametrize(['try_cnt'], [(i_,) for i_ in range(1, 6)])
+    @pytest.mark.parametrize(['max_read'], [(10,), (15,), (None,)])
+    def test_run_simple(self, serial, sending_thread, send_end_event, max_read, try_cnt):
+        time.sleep(1 + random.random() * 0.5)
+        retvals = []
+        if max_read is None:
+            max_read = 1 << 31
+
+        i = 0
+        while i < max_read:
+            try:
+                v = serial.next_value()
+            except Stopped:
+                break
+            else:
+                retvals.append(v)
+            i += 1
+
+        serial.shutdown()
+        assert retvals == [i ** 2 for i in range(min(20, max_read))]

--- a/test/utils/test_serial.py
+++ b/test/utils/test_serial.py
@@ -33,7 +33,7 @@ def send_20_nums(serial):
                 break
 
         event.set()
-        time.sleep(0.5)
+        time.sleep(1.0)
         serial.shutdown()
         serial.join()
 

--- a/test/utils/test_serial.py
+++ b/test/utils/test_serial.py
@@ -4,7 +4,7 @@ from threading import Event, Thread
 
 import pytest
 
-from waifuc.utils import SerializableParallelModule, Stopped
+from waifuc.utils import SerializableParallelModule, Stopped, NonSerializableParallelModule
 
 
 def _calc_fn(x):
@@ -22,7 +22,7 @@ def serial():
 
 
 @pytest.fixture()
-def send_20_nums(serial):
+def serial_send_20(serial):
     event = Event()
 
     def _t():
@@ -47,14 +47,60 @@ def send_20_nums(serial):
 
 
 @pytest.fixture()
-def sending_thread(send_20_nums):
-    thread, _ = send_20_nums
+def serial_sending_thread(serial_send_20):
+    thread, _ = serial_send_20
     yield thread
 
 
 @pytest.fixture()
-def send_end_event(send_20_nums):
-    _, event = send_20_nums
+def serial_send_end_event(serial_send_20):
+    _, event = serial_send_20
+    yield event
+
+
+@pytest.fixture()
+def non_serial():
+    s = NonSerializableParallelModule(max_workers=4)
+    try:
+        yield s
+    finally:
+        s.join()
+
+
+@pytest.fixture()
+def non_serial_send_20(non_serial):
+    event = Event()
+
+    def _t():
+        for i in range(20):
+            try:
+                non_serial.submit_task(_calc_fn, i)
+            except Stopped:
+                break
+
+        event.set()
+        time.sleep(1.0)
+        non_serial.shutdown()
+        non_serial.join()
+
+    thread = Thread(target=_t)
+    thread.start()
+
+    try:
+        yield thread, event
+    finally:
+        thread.join()
+
+
+@pytest.fixture()
+def non_serial_sending_thread(non_serial_send_20):
+    thread, _ = non_serial_send_20
+    yield thread
+
+
+@pytest.fixture()
+def non_serial_send_end_event(non_serial_send_20):
+    _, event = non_serial_send_20
     yield event
 
 
@@ -62,7 +108,7 @@ def send_end_event(send_20_nums):
 class TestUtilsSerial:
     @pytest.mark.parametrize(['try_cnt'], [(i_,) for i_ in range(1, 6)])
     @pytest.mark.parametrize(['max_read'], [(10,), (15,), (None,)])
-    def test_run_simple(self, serial, sending_thread, send_end_event, max_read, try_cnt):
+    def test_run_serial(self, serial, serial_sending_thread, serial_send_end_event, max_read, try_cnt):
         time.sleep(1 + random.random() * 0.5)
         retvals = []
         if max_read is None:
@@ -80,3 +126,26 @@ class TestUtilsSerial:
 
         serial.shutdown()
         assert retvals == [i ** 2 for i in range(min(20, max_read))]
+
+    @pytest.mark.parametrize(['try_cnt'], [(i_,) for i_ in range(1, 6)])
+    @pytest.mark.parametrize(['max_read'], [(10,), (15,), (None,)])
+    def test_run_non_serial(self, non_serial, non_serial_sending_thread, non_serial_send_end_event, max_read, try_cnt):
+        time.sleep(1 + random.random() * 0.5)
+        retvals = []
+        if max_read is None:
+            max_read = 1 << 31
+
+        i = 0
+        while i < max_read:
+            try:
+                v = non_serial.next_value()
+            except Stopped:
+                break
+            else:
+                retvals.append(v)
+            i += 1
+
+        non_serial.shutdown()
+        max_read = min(20, max_read)
+        retvals = sorted(retvals)
+        assert len(retvals) == max_read

--- a/waifuc/source/__init__.py
+++ b/waifuc/source/__init__.py
@@ -15,5 +15,5 @@ from .pixiv import BasePixivSource, PixivSearchSource, PixivUserSource, PixivRan
 from .sankaku import SankakuSource, PostOrder, Rating, FileType
 from .video import VideoSource
 from .wallhaven import WallHavenSource
-from .web import WebDataSource
+from .web import WebDataSource, BaseWebDataSource, ParallelWebDataSource
 from .zerochan import ZerochanSource

--- a/waifuc/source/web.py
+++ b/waifuc/source/web.py
@@ -1,6 +1,6 @@
 import os
 import warnings
-from typing import Iterator, Tuple, Union
+from typing import Iterator, Tuple, Union, Optional
 
 import requests
 from PIL import UnidentifiedImageError, Image
@@ -16,7 +16,7 @@ class NoURL(Exception):
     pass
 
 
-class WebDataSource(RootDataSource):
+class BaseWebDataSource(RootDataSource):
     def __init__(self, group_name: str, session: requests.Session = None, download_silent: bool = True):
         self.download_silent = download_silent
         self.session = session or get_requests_session()
@@ -25,25 +25,38 @@ class WebDataSource(RootDataSource):
     def _iter_data(self) -> Iterator[Tuple[Union[str, int], str, dict]]:
         raise NotImplementedError  # pragma: no cover
 
+    def _get_item(self, id_, url, meta) -> Optional[ImageItem]:
+        with TemporaryDirectory(ignore_cleanup_errors=True) as td:
+            _, ext_name = os.path.splitext(urlsplit(url).filename)
+            filename = f'{self.group_name}_{id_}{ext_name}'
+            td_file = os.path.join(td, filename)
+            try:
+                download_file(
+                    url, td_file, desc=filename,
+                    session=self.session, silent=self.download_silent
+                )
+                image = Image.open(td_file)
+                image.load()
+            except UnidentifiedImageError:
+                warnings.warn(f'{self.group_name.capitalize()} resource {id_} unidentified as image, skipped.')
+                return None
+            except (IOError, DecompressionBombError) as err:
+                warnings.warn(f'Skipped due to error: {err!r}')
+                return None
+
+            meta = {**meta, 'url': url}
+            return ImageItem(image, meta)
+
+    def _iter(self) -> Iterator[ImageItem]:
+        raise NotImplementedError  # pragma: no cover
+
+
+class WebDataSource(BaseWebDataSource):
+    def _iter_data(self) -> Iterator[Tuple[Union[str, int], str, dict]]:
+        raise NotImplementedError  # pragma: no cover
+
     def _iter(self) -> Iterator[ImageItem]:
         for id_, url, meta in self._iter_data():
-            with TemporaryDirectory(ignore_cleanup_errors=True) as td:
-                _, ext_name = os.path.splitext(urlsplit(url).filename)
-                filename = f'{self.group_name}_{id_}{ext_name}'
-                td_file = os.path.join(td, filename)
-                try:
-                    download_file(
-                        url, td_file, desc=filename,
-                        session=self.session, silent=self.download_silent
-                    )
-                    image = Image.open(td_file)
-                    image.load()
-                except UnidentifiedImageError:
-                    warnings.warn(f'{self.group_name.capitalize()} resource {id_} unidentified as image, skipped.')
-                    continue
-                except (IOError, DecompressionBombError) as err:
-                    warnings.warn(f'Skipped due to error: {err!r}')
-                    continue
-
-                meta = {**meta, 'url': url}
-                yield ImageItem(image, meta)
+            item = self._get_item(id_, url, meta)
+            if item is not None:
+                yield item

--- a/waifuc/utils/__init__.py
+++ b/waifuc/utils/__init__.py
@@ -2,5 +2,5 @@ from .context import task_ctx, get_task_names
 from .download import download_file
 from .idorder import IDOrder
 from .orderer import Orderer, SerializableOrderer, NoBlockOrderer
-from .serial import SerializableParallelModule, Stopped
+from .serial import SerializableParallelModule, Stopped, NonSerializableParallelModule
 from .session import get_requests_session, srequest, TimeoutHTTPAdapter

--- a/waifuc/utils/__init__.py
+++ b/waifuc/utils/__init__.py
@@ -2,4 +2,5 @@ from .context import task_ctx, get_task_names
 from .download import download_file
 from .idorder import IDOrder
 from .orderer import Orderer, SerializableOrderer, NoBlockOrderer
+from .serial import SerializableParallelModule, Stopped
 from .session import get_requests_session, srequest, TimeoutHTTPAdapter

--- a/waifuc/utils/__init__.py
+++ b/waifuc/utils/__init__.py
@@ -1,3 +1,4 @@
 from .context import task_ctx, get_task_names
 from .download import download_file
+from .orderer import Orderer, SerializableOrderer, NoBlockOrderer
 from .session import get_requests_session, srequest, TimeoutHTTPAdapter

--- a/waifuc/utils/__init__.py
+++ b/waifuc/utils/__init__.py
@@ -1,4 +1,5 @@
 from .context import task_ctx, get_task_names
 from .download import download_file
+from .idorder import IDOrder
 from .orderer import Orderer, SerializableOrderer, NoBlockOrderer
 from .session import get_requests_session, srequest, TimeoutHTTPAdapter

--- a/waifuc/utils/idorder.py
+++ b/waifuc/utils/idorder.py
@@ -1,0 +1,42 @@
+from threading import Lock, Event
+from typing import Set, Dict, Optional
+
+
+class IDOrder:
+    def __init__(self):
+        self._events: Dict[int, Event] = {}
+        self._exist_ids: Set[int] = set()
+        self._global_lock = Lock()
+
+    def set_id(self, id_: int):
+        with self._global_lock:
+            if id_ not in self._exist_ids:
+                self._exist_ids.add(id_)
+                if id_ in self._events:
+                    self._events[id_].set()
+                    del self._events[id_]
+
+    def _prepare_for_id(self, id_: int):
+        if id_ in self._exist_ids:
+            return None
+
+        if id_ not in self._events:
+            event = Event()
+            self._events[id_] = event
+        else:
+            event = self._events[id_]
+
+        return event
+
+    def wait_for_id(self, id_: int, timeout: Optional[float] = None) -> bool:
+        with self._global_lock:
+            event = self._prepare_for_id(id_)
+            if event is None:
+                return True
+
+        return event.wait(timeout=timeout)
+
+    def is_set_id(self, id_: int) -> bool:
+        with self._global_lock:
+            event = self._prepare_for_id(id_)
+            return True if event is None else event.is_set()

--- a/waifuc/utils/orderer.py
+++ b/waifuc/utils/orderer.py
@@ -3,16 +3,21 @@ from typing import Dict, Optional
 
 
 class Orderer:
+    def __init__(self):
+        self._current = -1
+
+    @property
+    def current(self):
+        return self._current
+
     def step(self) -> int:
-        raise NotImplementedError
+        raise NotImplementedError  # pragma: no cover
 
     def wait_for_num(self, num: int, timeout: Optional[float] = None) -> bool:
-        raise NotImplementedError
+        raise NotImplementedError  # pragma: no cover
 
 
 class NoBlockOrderer(Orderer):
-    def __init__(self):
-        self._current = -1
 
     def step(self) -> int:
         self._current += 1
@@ -24,8 +29,8 @@ class NoBlockOrderer(Orderer):
 
 class SerializableOrderer(Orderer):
     def __init__(self):
+        Orderer.__init__(self)
         self._events: Dict[int, Event] = {}
-        self._current = -1
         self._lock = Lock()
 
     def step(self) -> int:

--- a/waifuc/utils/orderer.py
+++ b/waifuc/utils/orderer.py
@@ -1,0 +1,53 @@
+from threading import Lock, Event
+from typing import Dict, Optional
+
+
+class Orderer:
+    def step(self) -> int:
+        raise NotImplementedError
+
+    def wait_for_num(self, num: int, timeout: Optional[float] = None) -> bool:
+        raise NotImplementedError
+
+
+class NoBlockOrderer(Orderer):
+    def __init__(self):
+        self._current = -1
+
+    def step(self) -> int:
+        self._current += 1
+        return self._current
+
+    def wait_for_num(self, num: int, timeout: Optional[float] = None) -> bool:
+        return True
+
+
+class SerializableOrderer(Orderer):
+    def __init__(self):
+        self._events: Dict[int, Event] = {}
+        self._current = -1
+        self._lock = Lock()
+
+    def step(self) -> int:
+        with self._lock:
+            self._current += 1
+            if self._current in self._events:
+                self._events[self._current].set()
+                del self._events[self._current]
+
+            return self._current
+
+    def wait_for_num(self, num: int, timeout: Optional[float] = None) -> bool:
+        if num < 0:
+            raise ValueError(f'Unsupported number {num!r}!')
+        with self._lock:
+            if num <= self._current:
+                return True
+
+            if num not in self._events:
+                event = Event()
+                self._events[num] = event
+            else:
+                event = self._events[num]
+
+        return event.wait(timeout=timeout)

--- a/waifuc/utils/serial.py
+++ b/waifuc/utils/serial.py
@@ -1,0 +1,112 @@
+import abc
+from concurrent.futures import Executor, ThreadPoolExecutor
+from threading import Lock, Event
+
+from .idorder import IDOrder
+from .orderer import SerializableOrderer
+
+
+class Stopped(Exception):
+    pass
+
+
+class ParallelModule(abc.ABC):
+    def submit_task(self, func, *args, **kwargs):
+        raise NotImplementedError
+
+    def shutdown(self):
+        raise NotImplementedError
+
+    def join(self):
+        raise NotImplementedError
+
+    def next_value(self):
+        raise NotImplementedError
+
+
+class SerializableParallelModule(ParallelModule):
+    def __init__(self, max_workers: int = None):
+        self._executor_value = None
+        self._max_workers = max_workers
+
+        # states
+        self._current_task_id = -1
+        self._retvals = {}
+        self._orderer = SerializableOrderer()
+        self._idorder = IDOrder()
+
+        # global signals
+        self._stop_event = Event()
+        self._global_lock = Lock()
+
+    @property
+    def _executor(self) -> Executor:
+        if self._executor_value is None:
+            self._executor_value = ThreadPoolExecutor(max_workers=self._max_workers)
+        return self._executor_value
+
+    def _wait_for_num_from_order(self, num):
+        while True:
+            if self._stop_event.is_set():
+                raise Stopped('Stopped. No order available.')
+
+            if self._orderer.wait_for_num(num, timeout=1.0):
+                return True
+
+    def _func_wrapper(self, id_: int, func, *args, **kwargs):
+        event = Event()
+
+        def _new_func():
+            event.set()
+            if self._stop_event.is_set():
+                return
+
+            retval = func(*args, **kwargs)
+
+            try:
+                self._wait_for_num_from_order(id_)
+            except Stopped:
+                pass
+            else:
+                with self._global_lock:
+                    self._retvals[id_] = retval
+                    self._idorder.set_id(id_)
+
+        return _new_func, event
+
+    def submit_task(self, func, *args, **kwargs):
+        with self._global_lock:
+            if self._stop_event.is_set():
+                raise Stopped('Stopped. New tasks no longer available.')
+
+            self._current_task_id += 1
+            func, start_event = self._func_wrapper(self._current_task_id, func, *args, **kwargs)
+            self._executor.submit(func)
+
+        start_event.wait()
+
+    def shutdown(self):
+        with self._global_lock:
+            self._executor.shutdown(wait=False)
+            self._stop_event.set()
+
+    def join(self):
+        self._stop_event.wait()
+        self._executor.shutdown(wait=True)
+
+    def next_value(self):
+        with self._global_lock:
+            if self._stop_event.is_set():
+                raise Stopped('Stopped. No more values available.')
+
+            self._orderer.step()
+            current = self._orderer.current
+
+        while True:
+            if self._stop_event.is_set():
+                raise Stopped('Stopped. No more values available.')
+
+            if self._idorder.wait_for_id(current, timeout=1.0):
+                retval = self._retvals[current]
+                del self._retvals[current]
+                return retval

--- a/waifuc/utils/serial.py
+++ b/waifuc/utils/serial.py
@@ -12,16 +12,16 @@ class Stopped(Exception):
 
 class ParallelModule(abc.ABC):
     def submit_task(self, func, *args, **kwargs):
-        raise NotImplementedError
+        raise NotImplementedError  # pragma: no cover
 
     def shutdown(self):
-        raise NotImplementedError
+        raise NotImplementedError  # pragma: no cover
 
     def join(self):
-        raise NotImplementedError
+        raise NotImplementedError  # pragma: no cover
 
     def next_value(self):
-        raise NotImplementedError
+        raise NotImplementedError  # pragma: no cover
 
 
 class SerializableParallelModule(ParallelModule):


### PR DESCRIPTION
The core code is in `waifuc.source.web.ParallelWebDataSource`.

It is based on `SerializableParallelModule, NonSerializableParallelModule, Stopped` in `waifuc.utils` (the unittests for them have passed).

The `ParallelWebDataSource` have the same api to `WebDataSource`, you can simply replace the base class of the data source classes to `ParallelWebDataSource` and add some more `__init__` arguments.

Here is an example of it

```python
import os.path
import re
from typing import Optional, Iterator, List, Tuple, Union

from ditk import logging
from hbutils.system import urlsplit
from requests.auth import HTTPBasicAuth

from waifuc.config.meta import __TITLE__, __VERSION__
from waifuc.export import SaveExporter
from waifuc.source.web import NoURL, ParallelWebDataSource
from waifuc.utils import get_requests_session, srequest

logging.try_init_root(logging.INFO)


class DanbooruLikeSource(ParallelWebDataSource):
    # just the same as the original DanbooruSource
    def __init__(self, tags: List[str], min_size: Optional[int] = 800, download_silent: bool = True,
                 username: Optional[str] = None, api_key: Optional[str] = None,
                 site_name: Optional[str] = 'danbooru', site_url: Optional[str] = 'https://danbooru.donmai.us/',
                 group_name: Optional[str] = None, max_workers: Optional[int] = None, serializable: bool = True):
        ParallelWebDataSource.__init__(self, group_name or site_name, None, download_silent, max_workers, serializable)
        self.session = get_requests_session(headers={
            "User-Agent": f"{__TITLE__}/{__VERSION__}",
            'Content-Type': 'application/json; charset=utf-8',
        })
        self.auth = HTTPBasicAuth(username, api_key) if username and api_key else None
        self.site_name, self.site_url = site_name, site_url
        self.tags = tags
        self.min_size = min_size

    def _get_data_from_raw(self, raw):
        return raw

    def _select_url(self, data):
        if self.min_size is not None and "media_asset" in data and "variants" in data["media_asset"]:
            variants = data["media_asset"]["variants"]
            width, height, url = None, None, None
            for item in variants:
                if 'width' in item and 'height' in item and \
                        item['width'] >= self.min_size and item['height'] >= self.min_size:
                    if url is None or item['width'] < width:
                        width, height, url = item['width'], item['height'], item['url']

            if url is not None:
                return url

        if 'file_url' not in data:
            raise NoURL

        return data['file_url']

    def _get_tags(self, data):
        return re.split(r'\s+', data["tag_string"])

    def _iter_data(self) -> Iterator[Tuple[Union[str, int], str, dict]]:
        page = 1
        while True:
            resp = srequest(self.session, 'GET', f'{self.site_url}/posts.json', params={
                "format": "json",
                "limit": "100",
                "page": str(page),
                "tags": ' '.join(self.tags),
            }, auth=self.auth)
            resp.raise_for_status()
            page_items = self._get_data_from_raw(resp.json())
            if not page_items:
                break

            for data in page_items:
                try:
                    url = self._select_url(data)
                except NoURL:
                    continue

                _, ext_name = os.path.splitext(urlsplit(url).filename)
                filename = f'{self.group_name}_{data["id"]}{ext_name}'
                meta = {
                    self.site_name: data,
                    'group_id': f'{self.group_name}_{data["id"]}',
                    'filename': filename,
                    'tags': {key: 1.0 for key in self._get_tags(data)}
                }
                yield data['id'], url, meta

            page += 1


class DanbooruSource(DanbooruLikeSource):
    def __init__(self, tags: List[str],
                 min_size: Optional[int] = 800, download_silent: bool = True,
                 username: Optional[str] = None, api_key: Optional[str] = None,
                 group_name: Optional[str] = None, max_workers: Optional[int] = None, serializable: bool = True):
        DanbooruLikeSource.__init__(self, tags, min_size, download_silent, username, api_key,
                                    'danbooru', 'https://danbooru.donmai.us/', group_name, max_workers, serializable)


if __name__ == '__main__':
    s = DanbooruSource(
        ['surtr_(arknights)'],
        max_workers=4,
        serializable=False,  # the items will be in order when True
        download_silent=False,  # hide the download progress bar when True
    )
    s[:100].export(SaveExporter('test_zerochan_imgs', no_meta=True))  # download the first 100 images
    s.cleanup()  # TODO: we don't want this line is possible

```

