### PR TITLE
dev(narugo): allow use string as exporter (equals to SaveExporter('xx…

### DIFF
--- a/waifuc/source/base.py
+++ b/waifuc/source/base.py
@@ -1,5 +1,5 @@
 import copy
-from typing import Iterator, Optional
+from typing import Iterator, Optional, Union
 
 from tqdm.auto import tqdm
 
@@ -58,7 +58,11 @@ class BaseDataSource:
     def attach(self, *actions: BaseAction) -> 'AttachedDataSource':
         return AttachedDataSource(self, *actions)
 
-    def export(self, exporter: BaseExporter, name: Optional[str] = None):
+    def export(self, exporter: Union[BaseExporter, str], name: Optional[str] = None):
+        if isinstance(exporter, str):
+            from ..export import SaveExporter
+            exporter = SaveExporter(exporter, no_meta=True)
+
         exporter = copy.deepcopy(exporter)
         exporter.reset()
         with task_ctx(name):


### PR DESCRIPTION
```python
from ditk import logging

from waifuc.action import FileExtAction, ModeConvertAction
from waifuc.source import ZerochanSource

logging.try_init_root(level=logging.INFO)

ZerochanSource('Texas', select='full', strict=True).attach(
    ModeConvertAction(),
    FileExtAction('.jpg'),
)[:10].export('test_q')

# equals to `SaveExporter('test_q', no_meta=True)`
```