### PR TITLE
dev(narugo): allow to scrap all the frames

### DIFF
--- a/waifuc/source/video.py
+++ b/waifuc/source/video.py
@@ -4,6 +4,7 @@ import os
 from typing import Iterator, Optional
 from urllib.error import HTTPError
 
+from hbutils.scale import time_to_delta_str
 from tqdm.auto import tqdm
 
 from .base import EmptySource, NamedDataSource, BaseDataSource
@@ -24,12 +25,14 @@ _DEFAULT_MIN_FRAME_INTERVAL: float = 0.5
 
 
 class VideoSource(NamedDataSource):
-    def __init__(self, video_file, min_frame_interval: Optional[float] = _DEFAULT_MIN_FRAME_INTERVAL):
+    def __init__(self, video_file, min_frame_interval: Optional[float] = _DEFAULT_MIN_FRAME_INTERVAL,
+                 key_frames_only: bool = False):
         if not _VIDEO_EXTRACT_AVAILABLE:
             raise ImportError(f'pyav not installed, {self.__class__.__name__} is unavailable. '
                               f'Please install this with `pip install git+https://github.com/deepghs/waifuc.git@main#egg=waifuc[video]` to solve this problem.')
-        self.video_file = video_file
+        self.video_file = os.path.abspath(video_file)
         self.min_frame_interval = min_frame_interval
+        self.key_frames_only = key_frames_only
 
     def _args(self):
         return [self.video_file]
@@ -45,11 +48,14 @@ class VideoSource(NamedDataSource):
             _last_frame_time = None
             with av.open(content) as container:
                 stream = container.streams.video[0]
-                stream.codec_context.skip_frame = "NONKEY"
+                total_time = float(stream.time_base * stream.duration)
+                stream.codec_context.skip_frame = "NONKEY" if self.key_frames_only else "DEFAULT"
 
-                for i, frame in enumerate(tqdm(
-                        container.decode(stream),
-                        desc=f'Video Extracting - {os.path.basename(self.video_file)}')):
+                pg = tqdm(
+                    total=int(total_time),
+                    desc=f'Video Extracting - {os.path.basename(self.video_file)}'
+                )
+                for i, frame in enumerate(container.decode(stream), ):
                     if self.min_frame_interval is None or \
                             _last_frame_time is None or frame.time - _last_frame_time >= self.min_frame_interval:
                         filebody, _ = os.path.splitext(os.path.basename(self.video_file))
@@ -60,13 +66,18 @@ class VideoSource(NamedDataSource):
                             'filename': f'{filebody}_time_{frame.time:.3f}s.png',
                         }
                         yield ImageItem(frame.to_image(), meta)
+                        pg.update(int(frame.time) - int(_last_frame_time or 0.0))
                         _last_frame_time = frame.time
+                        pg.set_description(f'Video Extracting - {os.path.basename(self.video_file)} - '
+                                           f'{time_to_delta_str(int(frame.time))} / '
+                                           f'{time_to_delta_str(int(total_time))}')
         except (InvalidDataError, av.error.ValueError, IndexError, UnicodeError) as err:
             logging.warning(f'Video extraction skipped due to error - {err!r}')
 
     @classmethod
     def from_directory(cls, directory: str, recursive: bool = True,
-                       min_frame_interval: float = _DEFAULT_MIN_FRAME_INTERVAL) -> BaseDataSource:
+                       min_frame_interval: float = _DEFAULT_MIN_FRAME_INTERVAL,
+                       key_frames_only: bool = False) -> BaseDataSource:
         if recursive:
             files = glob.glob(os.path.join(glob.escape(directory), '**', '*'), recursive=True)
         else:
@@ -77,5 +88,5 @@ class VideoSource(NamedDataSource):
             if os.path.isfile(file) and os.access(file, os.R_OK):
                 file_type_ = get_file_type(file)
                 if file_type_ and 'video' in file_type_:
-                    source = source + cls(file, min_frame_interval=min_frame_interval)
+                    source = source + cls(file, min_frame_interval=min_frame_interval, key_frames_only=key_frames_only)
         return source


### PR DESCRIPTION
* Extract from one video file, extract all frames, with minimal time interval 0.5secs

```python
from waifuc.source import VideoSource

# extract all frames, with minimal time interval 0.5s 
s = VideoSource('1.mp4', key_frames_only=False)
s.export('/data/video_frames')

```

* Extract from video directory, extract key frames only, with minimal time interval 0.2secs

```python
from waifuc.source import VideoSource

# extract key frames only, with minimal time interval 0.2s
s = VideoSource.from_directory('/your/directory', min_frame_interval=0.2)
s.export('/data/video_frames')

```