### PR TITLE
fix `PixivSearchSource` no data error

### DIFF
--- a/waifuc/source/pixiv.py
+++ b/waifuc/source/pixiv.py
@@ -204,6 +204,7 @@ class PixivSearchSource(BasePixivSource):
         self.end_date = end_date
         self.filter = filter
         self.req_auth = req_auth
+        self.no_ai = int(no_ai)
 
     def _args(self):
         return [self.word]
@@ -212,7 +213,7 @@ class PixivSearchSource(BasePixivSource):
         offset = 0
         while True:
             data = self.client.search_illust(self.word, self.search_target, self.sort, self.duration,
-                                             self.start_date, self.end_date, self.filter, offset, self.req_auth)
+                                             self.start_date, self.end_date, self.filter, self.no_ai, offset, self.req_auth)
             if 'illusts' not in data:
                 logging.warning(f'Illusts not found in page (offset: {offset!r}), skipped: {data!r}.')
                 break


### PR DESCRIPTION
When I run the `PixivSearchSource` example code from the official documentation, the program does not scrape any data and instead throws a warning:
![error](https://github.com/deepghs/waifuc/assets/33629016/7ee9c7be-6cdc-491f-bffa-d10ef32663c9)

According to the code at https://github.com/upbit/pixivpy/blob/3273654796ebe1520c17145dd8e213f946a34682/pixivpy3/aapi.py#L473, it is because the `search_ai_type` parameter was not passed. After adding this parameter, the code runs normally.