### PR TITLE
save pixiv animated image as "webp" rather than "gif". close file poi…

### DIFF
--- a/waifuc/source/pixiv.py
+++ b/waifuc/source/pixiv.py
@@ -105,7 +105,7 @@ class BasePixivSource(WebDataSource):
                     all_frames.append(frame_img)
                     all_durations.append(frame['delay'])
 
-            gif_file = os.path.join(td, os.path.splitext(filename)[0] + '.gif')
+            gif_file = os.path.join(td, os.path.splitext(filename)[0] + '.webp')
             all_frames[0].save(
                 gif_file,
                 save_all=True,
@@ -115,6 +115,8 @@ class BasePixivSource(WebDataSource):
             )
 
             gif_img = Image.open(gif_file)
+            gif_img.load()
+            gif_img._close_fp()
             return gif_img
 
     def _iter_data(self) -> Iterator[Tuple[Union[str, int], str, dict]]:
@@ -170,10 +172,9 @@ class BasePixivSource(WebDataSource):
 
                 try:
                     gif_image = self._make_gif_for_ugoira(frame_infos, zip_url)
-                    gif_image.load()
                 except _UgoiraSkip:
                     continue
-                filename = f'{self.group_name}_{illust["id"]}.gif'
+                filename = f'{self.group_name}_{illust["id"]}.webp'
                 meta = {
                     'pixiv': illust,
                     'ugoira': metadata,


### PR DESCRIPTION
保存为GIF文件时，由于pillow的gif解码器必须持有文件指针才能解码，所以无法在打开后无法删除图片文件。如果将gif改为webp格式，则可以在加载后关闭文件，从而解决无法删除临时文件夹的问题，此外webp格式的动图质量比gif更高，动态效果更流畅。

注意：部分软件无法正常显示webp动图，只显示第一帧，例如window10系统的图片查看器。